### PR TITLE
Support Yoga Pro 7 14ASP10-style packages, add safety checks and diagnostics, improve documentation and metadata accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ To fix this, run the script again passing `X` as its second argument. For exampl
 
 Replace the version format keyword as needed.
 
+### Device X [System Firmware] does not currently allow updates
+
+fwupd will refuse to install BIOS updates on devices running on battery; plug in the charger and try again.
+
 ## License
 
 GPLv2. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -81,16 +81,19 @@ If one is not, you'll get a warning: it may be a component that only the Windows
 
 ## Tested laptops
 
-| Model                     | Status          |
-|---------------------------|-----------------|
-| Legion Pro 7 16IAX10H     | Tested, working |
-| IdeaPad Pro 5 16IAH10     | Tested, working |
-| Yoga 9 2in-1 14ILL10      | Tested, working |
-| Legion 5 15AHP10          | Tested, working |
-| Yoga Pro 7 Gen 10 14ASP10 | Tested, working |
+| Model                     | Status                                          |
+|---------------------------|-------------------------------------------------|
+| Legion Pro 7 16IAX10H     | Tested, working                                 |
+| IdeaPad Pro 5 16IAH10     | Tested, working                                 |
+| Yoga 9 2in-1 14ILL10      | Tested, working                                 |
+| Legion 5 15AHP10          | Tested, working                                 |
+| Yoga Pro 7 Gen 10 14ASP10 | Tested, working                                 |
+| Legion Pro 7 16AFR10H     | `.cab` generated and validated, but not flashed |
 
 > [!NOTE]
-> This script was used to successfully update the Yoga Pro 7 14ASP10 from version QFCN26WW to QFCN29WW, so it should be safe to skip intermediate images and just use the latest available one.
+> - This script was used to successfully update the Yoga Pro 7 14ASP10 from version QFCN26WW to QFCN29WW, so it should be safe to skip intermediate images and just use the latest available one.
+>
+> - On the Legion Pro 7 16AFR10H the script passed every check and produced a `.cab`, but it was not installed, because that machine was already on the most recent BIOS version at the time of writing this (`SMCN20WW`). Treat it as evidence that the packaging works on that model, not that the flash does.
 
 This script should work on other Lenovo laptops that use Insyde H2OFFT-based BIOS updates with a `.fd` or `.bin` firmware file inside the `.exe`. If you test it on another model, please open an issue or PR to update this table.
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ The script will:
 3. Check that any other firmware blobs in the package are inside that image.
 4. Read the BIOS version string from the firmware image.
 5. Read your system's firmware GUID and current version from the ESRT.
-6. Generate fwupd-compatible metainfo XML.
-7. Package everything into a `.cab` file.
+6. Check the image targets this machine: its System Firmware GUID must match the `fw_type=1` entry in the ESRT, and the four-character platform code in its version string must match `/sys/class/dmi/id/bios_version`. Both are fatal on mismatch; the second is skipped on models whose BIOS version does not follow that scheme. Note that neither check subsumes the other: two Legion Pro 7 models with different silicon (16IAX10H/16AFR10H, Intel/AMD) share a System Firmware GUID and are distinguished only by the platform code, while the platform code check is skipped entirely on machines using a different version scheme.
+7. Generate fwupd-compatible metainfo XML.
+8. Package everything into a `.cab` file.
 
 Then install the resulting `.cab`:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The script will:
 7. Generate fwupd-compatible metainfo XML.
 8. Package everything into a `.cab` file.
 
+> [!NOTE]
+> The script will ask for root, but it's only used to read data from the otherwise-protected ESRT EFI entries.
+> That said, as with any script you run with elevated privileges, you are encouraged to [read it](./lenovo-bios-fwupd.sh) before running it. The script is short, commented, and does only what is described above.
+
 Then install the resulting `.cab`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ If one is not, you'll get a warning: it may be a component that only the Windows
 
 This script should work on other Lenovo laptops that use Insyde H2OFFT-based BIOS updates with a `.fd` or `.bin` firmware file inside the `.exe`. If you test it on another model, please open an issue or PR to update this table.
 
+## Troubleshooting
+
+### Firmware version formats were different, device was 'X' and release is 'Y'
+
+When trying to install a successfully packaged `.cab`, you may get the above error. For example, on the Yoga Pro 7 14ASP10, you'll get:
+
+```
+Firmware version formats were different, device was 'number' and release is 'plain'
+```
+
+To fix this, run the script again passing `X` as its second argument. For example, in the case of the above error, use:
+```bash
+./lenovo-bios-fwupd.sh <bios_update.exe> number
+```
+
+Replace the version format keyword as needed.
+
 ## License
 
 GPLv2. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ If one is not, you'll get a warning: it may be a component that only the Windows
 
 This script should work on other Lenovo laptops that use Insyde H2OFFT-based BIOS updates with a `.fd` or `.bin` firmware file inside the `.exe`. If you test it on another model, please open an issue or PR to update this table.
 
+Please paste the output of the script in your issue. If it warns that a secondary binary is not contained in the main firmware image, that would be especially useful to see, as none of the machines tested so far have exhibited this case. More generally, the output will help better understand how Lenovo packages firmware across different models.
+
 ## Troubleshooting
 
 ### Firmware version formats were different, device was 'X' and release is 'Y'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Many Lenovo laptops don't receive BIOS updates through [LVFS](https://fwupd.org/
 - `7z` (p7zip)
 - `gcab`
 - `fwupdmgr` (fwupd)
+- `python3`
 
 ## Downloading the BIOS update
 
@@ -28,11 +29,12 @@ Many Lenovo laptops don't receive BIOS updates through [LVFS](https://fwupd.org/
 The script will:
 
 1. Extract the `.exe` archive with `7z`.
-2. Locate the `.fd` firmware file inside.
-3. Parse the BIOS version string from the filename.
-4. Read your system's firmware GUID and current version from the ESRT.
-5. Generate fwupd-compatible metainfo XML.
-6. Package everything into a `.cab` file.
+2. Locate the firmware image inside, using `platform.ini` to decide which file it is.
+3. Check that any other firmware blobs in the package are inside that image.
+4. Read the BIOS version string from the firmware image.
+5. Read your system's firmware GUID and current version from the ESRT.
+6. Generate fwupd-compatible metainfo XML.
+7. Package everything into a `.cab` file.
 
 Then install the resulting `.cab`:
 
@@ -46,16 +48,46 @@ Reboot to apply the update. The UEFI firmware will apply the capsule during boot
 
 **Important:** Ensure AC power is connected and battery is above 30% before installing. Do **not** interrupt the reboot after installation.
 
+## How the firmware image is located
+
+`platform.ini` has an `[FDFile]` section naming the image to flash. Insyde's own documentation, embedded in that same file, states that when `FileName` is empty the utility loads the first `.fd` file it finds, which is the case on the Legion and IdeaPad packages. Others, such as the Yoga Pro 7 14ASP10, name the image explicitly, and it need not be a `.fd`:
+
+```ini
+[FDFile]
+FileName=KLS7A.bin
+;(wW)
+;FileName          default : empty.
+;                   String : Utility always load this file.
+;                            If the FileName is empty, utility will search current directory
+;                              and load the first found FD file.
+```
+
+The script honors the key when it is set and falls back to the first `.fd` when it is empty, so previously supported models are unaffected. Despite the differing extension, the two are the same kind of artifact.
+
+Some packages ship other firmware blobs alongside the image; the Yoga Pro 7 14ASP10 includes `Ecb.bin`, ITE IT5508 embedded controller firmware. It is contained verbatim inside the main image and `platform.ini` leaves the separate-EC-image path disabled, so ignoring it is safe. More generally, since the `.cab` carries only the `FileName` image from above, the script checks whether each extra blob is already inside it:
+
+```
+  OK: Secondary firmware Ecb.bin is contained in KLS7A.bin at 0x1817b0
+```
+
+If one is not, you'll get a warning: it may be a component that only the Windows updater flashes (via a separate path, like the Intel firmware update tool `FWUpdLcl.exe`), in which case this update will leave it on its current version.
+
+*Note*: all tested laptops so far either contain a single image, or ship exactly one redundant secondary image; the above was inferred from the Insyde documentation contained inside `platform.ini`.
+
 ## Tested laptops
 
-| Model                 | Status          |
-|-----------------------|-----------------|
-| Legion Pro 7 16IAX10H | Tested, working |
-| IdeaPad Pro 5 16IAH10 | Tested, working |
-| Yoga 9 2in-1 14ILL10  | Tested, working |
-| Legion 5 15AHP10      | Tested, working |
+| Model                     | Status          |
+|---------------------------|-----------------|
+| Legion Pro 7 16IAX10H     | Tested, working |
+| IdeaPad Pro 5 16IAH10     | Tested, working |
+| Yoga 9 2in-1 14ILL10      | Tested, working |
+| Legion 5 15AHP10          | Tested, working |
+| Yoga Pro 7 Gen 10 14ASP10 | Tested, working |
 
-This script should work on other Lenovo laptops that use Insyde H2OFFT-based BIOS updates with a `.fd` firmware file inside the `.exe`. If you test it on another model, please open an issue or PR to update this table.
+> [!NOTE]
+> This script was used to successfully update the Yoga Pro 7 14ASP10 from version QFCN26WW to QFCN29WW, so it should be safe to skip intermediate images and just use the latest available one.
+
+This script should work on other Lenovo laptops that use Insyde H2OFFT-based BIOS updates with a `.fd` or `.bin` firmware file inside the `.exe`. If you test it on another model, please open an issue or PR to update this table.
 
 ## License
 

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # lenovo-bios-fwupd.sh
-# Version 1.0
+# Version 2.0
 # Nadim Kobeissi -- https://github.com/nadimkobeissi/lenovo-bios-fwupd
 #
 # Converts a Lenovo Windows BIOS update .exe (Insyde H2OFFT based) into a

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -23,11 +23,26 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 # Argument parsing
 # --------------------------------------------------------------------------- #
 EXE="${1:-}"
+VERSION_FORMAT="${2:-plain}"
 
 if [[ "$EXE" == "--help" || "$EXE" == "-h" ]]; then
-    echo "Usage: $0 <bios_update.exe>"
+    echo "Usage: $0 <bios_update.exe> [version-format]"
     echo ""
     echo "Converts a Lenovo Windows BIOS .exe into a fwupd .cab file."
+    echo ""
+    echo "If you get this error while trying to install the generated .cab:"
+    echo ""
+    echo "  Firmware version formats were different, device was 'X' and release is 'Y'"
+    echo ""
+    echo "run again the script like this:"
+    echo "$0 <bios_update.exe> X"
+    echo "where X is what the error message said."
+    echo ""
+    echo "For example, if you got"
+    echo ""
+    echo "  Firmware version formats were different, device was 'number' and release is 'plain'"
+    echo ""
+    echo "use: $0 <bios_update.exe> number"
     exit 0
 fi
 
@@ -261,7 +276,7 @@ cat > "$WORK/firmware.metainfo.xml" <<METAINFO
     </release>
   </releases>
   <custom>
-    <value key="LVFS::VersionFormat">plain</value>
+    <value key="LVFS::VersionFormat">$VERSION_FORMAT</value>
   </custom>
 </component>
 METAINFO

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -169,7 +169,8 @@ done
 # --------------------------------------------------------------------------- #
 # Read the BIOS version string
 #
-# Used for the .cab filename and the metainfo description.
+# Used for the .cab filename, the metainfo description, and the platform code
+# check further down.
 #
 # Insyde images carry a BIOS Version Data Table, introduced by a $BVDT tag and
 # followed by '$'-prefixed, NUL-terminated records; the first non-empty record
@@ -236,6 +237,72 @@ Is this a UEFI system with an EFI System Resource Table?"
 
 echo "==> System Firmware GUID: $FW_GUID"
 echo "==> Current firmware version (ESRT): $FW_CURRENT_VERSION"
+
+# --------------------------------------------------------------------------- #
+# Verify the image targets this machine.
+#
+# Insyde images embed the ESRT System Firmware GUID they belong to.
+# For simplicity, rather than locating and decoding it, convert this machine's
+# GUID to its raw 16 bytes and check whether the image contains them.
+#
+# Note this GUID is per-family, not per-model: the Legion Pro 7 16IAX10H
+# (Intel, Q7CN78WW) and 16AFR10H (AMD, SMCN20WW) packages both carry
+# be248459-caf2-4b09-af02-69b6a49974c1, and are told apart only by the
+# platform code check below. Conversely, that check is skipped on machines
+# whose BIOS version doesn't follow the ...NNWW scheme, where this is the
+# only compatibility check that runs. Neither subsumes the other.
+# --------------------------------------------------------------------------- #
+if python3 -c '
+import sys, uuid
+image = open(sys.argv[1], "rb").read()
+sys.exit(0 if uuid.UUID(sys.argv[2]).bytes_le in image else 1)
+' "$FD_FILE" "$FW_GUID"; then
+    echo "  OK: $FD_BASENAME targets this machine's System Firmware GUID."
+else
+    die "$FD_BASENAME does not reference this machine's System Firmware GUID
+($FW_GUID). This package is for a different device."
+fi
+
+# --------------------------------------------------------------------------- #
+# Second, independent compatibility check.
+#
+# The GUID check above compares the image against the ESRT. This one compares a
+# different field of the image -- its embedded version string -- against a
+# different source on the machine, /sys/class/dmi/id/bios_version.
+#
+# On the Yoga, Legion and IdeaPad models this script is known to work with,
+# those version strings take the form of a four-character code identifying the
+# board family, two digits for the BIOS version, then "WW" -- e.g. QFCN29WW,
+# Q7CN78WW. Where both sides use that form, the four-character codes must
+# agree.
+# This was explicitly verified by direct inspection of a Yoga Pro 7 14ASP10,
+# BIOS versions QFCN26WW - QFCN28WW - QFCN29WW, as well as Legion Pro 7i 16IAX10H
+# BIOS Q7CN78WW and Legion Pro 7 16AFR10H BIOS SMCN20WW.
+#
+# This is not a universal Lenovo convention, though; for example, ThinkPads
+# use a different form -- but this script may not be needed there in the
+# first place since many of those models are served by LVFS.
+#
+# So the check only runs when the machine reports a version in the form above:
+# 4 characters, 2 numbers, WW.
+# Comparing version strings we do not recognise risks refusing a package that
+# is in fact correct, so on other schemes we report that only the first check
+# was run rather than guessing.
+# --------------------------------------------------------------------------- #
+DMI_BIOS_VERSION=$(cat /sys/class/dmi/id/bios_version 2>/dev/null)
+
+if [[ "$DMI_BIOS_VERSION" =~ ^[A-Z0-9]{4}[0-9]{2}WW ]]; then
+    if [[ "${BIOS_VERSION:0:4}" == "${DMI_BIOS_VERSION:0:4}" ]]; then
+        echo "  OK: Platform code matches: ${BIOS_VERSION:0:4} (machine on $DMI_BIOS_VERSION, package $BIOS_VERSION)"
+    else
+        die "Platform code mismatch.
+  image  : $BIOS_VERSION
+  machine: $DMI_BIOS_VERSION"
+    fi
+else
+    echo "==> Platform code check skipped: this machine reports BIOS version"
+    echo "    '$DMI_BIOS_VERSION', which is not the scheme this check knows."
+fi
 
 # --------------------------------------------------------------------------- #
 # Determine the version number to put in the .cab metadata

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -322,7 +322,18 @@ DMI_BIOS_VERSION=$(cat /sys/class/dmi/id/bios_version 2>/dev/null)
 
 if [[ "$DMI_BIOS_VERSION" =~ ^[A-Z0-9]{4}[0-9]{2}WW ]]; then
     if [[ "${BIOS_VERSION:0:4}" == "${DMI_BIOS_VERSION:0:4}" ]]; then
-        ok "Platform code matches: ${BIOS_VERSION:0:4} (machine on $DMI_BIOS_VERSION, package $BIOS_VERSION)"
+        ok "Platform code matches: ${BIOS_VERSION:0:4}"
+
+        IMAGE_VERSION="${BIOS_VERSION:4:2}"
+        MACHINE_VERSION="${DMI_BIOS_VERSION:4:2}"
+
+        if [[ "$IMAGE_VERSION" == "$MACHINE_VERSION" ]]; then
+            warn "This machine already has BIOS version $DMI_BIOS_VERSION; continuing anyway"
+        elif [[ $IMAGE_VERSION -lt $MACHINE_VERSION ]]; then
+            die "This machine has BIOS version $DMI_BIOS_VERSION, but package includes the older version $BIOS_VERSION"
+        else
+            ok "Machine on BIOS version $DMI_BIOS_VERSION, package on $BIOS_VERSION"
+        fi
     else
         die "Platform code mismatch.
   image  : $BIOS_VERSION

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -75,6 +75,16 @@ if [[ "$EUID" -ne 0 ]]; then
 fi
 
 # --------------------------------------------------------------------------- #
+# Collect system information for user reports
+# --------------------------------------------------------------------------- #
+echo "==> System information:"
+echo "    Product name:         $(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+echo "    Product family:       $(cat /sys/class/dmi/id/product_family 2>/dev/null)"
+echo "    Current BIOS version: $(cat /sys/class/dmi/id/bios_version 2>/dev/null)"
+echo "    EC firmware release:  $(cat /sys/class/dmi/id/ec_firmware_release 2>/dev/null)"
+echo "==> Version format: $VERSION_FORMAT"
+
+# --------------------------------------------------------------------------- #
 # Set up working directory
 # --------------------------------------------------------------------------- #
 WORK=$(mktemp -d)

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -10,7 +10,7 @@
 # Usage:
 #   ./lenovo-bios-fwupd.sh <bios_update.exe>
 #
-# Requirements: 7z, gcab, fwupdmgr
+# Requirements: 7z, gcab, fwupdmgr, python3
 #
 # IMPORTANT: Ensure AC power is connected and battery is above 30% before
 # installing. Do NOT interrupt the reboot after installation.
@@ -37,7 +37,7 @@ fi
 # --------------------------------------------------------------------------- #
 # Dependency checks
 # --------------------------------------------------------------------------- #
-for cmd in 7z gcab fwupdmgr; do
+for cmd in 7z gcab fwupdmgr python3; do
     command -v "$cmd" &>/dev/null || die "'$cmd' is required but not found. Please install it."
 done
 
@@ -51,19 +51,153 @@ echo "==> Extracting $EXE ..."
 7z x -o"$WORK/extracted" "$EXE" -bso0 -bsp0
 
 # --------------------------------------------------------------------------- #
-# Locate the .fd firmware file
+# Locate the firmware image
+# H2OFFT's platform.ini has an [FDFile] section with a FileName key. The Insyde
+# documentation embedded in that same file states that when FileName is empty,
+# the utility searches the current directory and loads the first .fd file it
+# finds. That is the case on the supported Legion and IdeaPad packages.
+# Instead, for other devices (like the Yoga Pro 7 14ASP10),
+# the package explicitly names a file, which need not be .fd:
+#
+#    [FDFile]
+#    FileName=KLS7A.bin
+#
+# Therefore we read that section to determine which file to use.
 # --------------------------------------------------------------------------- #
-FD_FILE=$(find "$WORK/extracted" -maxdepth 1 -iname '*.fd' | head -1)
-[[ -n "$FD_FILE" ]] || die "No .fd firmware file found in the archive."
+PLATFORM_INI=$(find "$WORK/extracted" -maxdepth 1 -iname 'platform.ini')
+FD_FILE=""
+
+if [[ -n "$PLATFORM_INI" ]]; then
+    # [MULTI_FD] is the other, non-default way a package can say which image to
+    # flash; compared to FDFile, it lets several images ship together.
+    # We can't reproduce that behavior with a fwupd capsule containing a single
+    # image, and just picking the first .fd found would be arbitrary, so refuse
+    # rather than guess.
+    # Note: all packages examined so far have Flag=0 and conversely ship a single
+    # BIOS firmware image.
+    MULTI_FD_FLAG=$(awk '/^\[MULTI_FD\]/{f=1;next} f&&/^\[/{exit} f' "$PLATFORM_INI" \
+                    | grep -m1 '^Flag=' | cut -d= -f2- | tr -d '\r')
+    if [[ "$MULTI_FD_FLAG" == "1" ]]; then
+        die "platform.ini enables [MULTI_FD]: this package contains several firmware images selected by hardware detection, which this script cannot reproduce."
+    fi
+
+    # Print the [FDFile] section only, then take its FileName key.
+    INI_FDFILE=$(sed -n '/^\[FDFile\]/,/^\[/p' "$PLATFORM_INI" \
+                 | grep -m1 '^FileName=' | cut -d= -f2- | tr -d '\r')
+
+    if [[ -n "$INI_FDFILE" ]]; then
+        echo "==> platform.ini [FDFile] FileName=$INI_FDFILE"
+        FD_FILE=$(find "$WORK/extracted" -maxdepth 1 -iname "$INI_FDFILE")
+        [[ -n "$FD_FILE" ]] || die "platform.ini names '$INI_FDFILE' but it is not in the archive."
+    fi
+fi
+
+if [[ -z "$FD_FILE" ]]; then
+    FD_FILE=$(find "$WORK/extracted" -maxdepth 1 -iname '*.fd' | head -1) # first .fd file found
+    [[ -n "$FD_FILE" ]] || die "No firmware image found: platform.ini named none and no .fd file is present."
+fi
+
 FD_BASENAME=$(basename "$FD_FILE")
-echo "==> Found firmware: $FD_BASENAME"
+echo "==> Found firmware: $FD_BASENAME ($(stat -c%s "$FD_FILE") bytes)"
 
 # --------------------------------------------------------------------------- #
-# Read the BIOS version string from the .fd filename
-#   Lenovo convention: WinQ7CN45WW.fd -> version string is Q7CN45WW
+# Account for any other firmware blobs in the package.
+#
+# platform.ini names a single image, and the .cab we build contains only that
+# image.
+# The Yoga Pro 7 14ASP10 ships Ecb.bin: ITE IT5508 embedded controller
+# firmware, identified by the string "UUITE5508-COMPAL01EC-USER0-BS-CODE" it
+# carries. It is present byte-for-byte inside the main image, once, at
+# 0x1817b0, in both the QFCN28WW and QFCN29WW update packages.
+#
+# platform.ini's [UpdateEC] section describes how a *separate* EC image would be
+# flashed: EC_Path names the file, valid only when Flag=1 ("Flash EC by BIOS").
+# Here Flag=0 and EC_Path is empty in every package examined, so that path is
+# unused. The EC region is instead written as part of the BIOS image itself.
+# Therefore, the standalone copy is redundant and it's safe to ignore it.
+#
+# Not every secondary blob would be. The same file defines MEFileName for an
+# Intel ME image, flashed by a separate tool (FWUpdLcl.exe) inside Windows and
+# before the BIOS -- therefore, such a blob would likely be separate from the
+# BIOS image. Hence: warn and say what the user is missing.
+
+# Overall the check below implements the following heuristics:
+# if a secondary blob is present verbatim inside the main image,
+# the capsule already carries it and nothing is lost by ignoring it.
+# If it is not, this update may leave that component on its old version.
+# That should be recoverable rather than fatal, so warn rather than refuse.
 # --------------------------------------------------------------------------- #
-BIOS_VERSION=$(echo "$FD_BASENAME" | sed -E 's/^Win//i; s/\.fd$//i')
-echo "==> BIOS version string: $BIOS_VERSION"
+mapfile -t EXTRA_IMAGES < <(find "$WORK/extracted" -maxdepth 1 \
+    \( -iname '*.bin' -o -iname '*.fd' \) \
+    ! -samefile "$FD_FILE" | sort)
+
+for extra in "${EXTRA_IMAGES[@]}"; do
+    extra_name=$(basename "$extra")
+    offset=$(python3 -c '
+import sys
+haystack = open(sys.argv[1], "rb").read()
+needle = open(sys.argv[2], "rb").read()
+print(haystack.find(needle) if needle else -1)
+' "$FD_FILE" "$extra" 2>/dev/null || echo -1)
+
+    if [[ "$offset" =~ ^[0-9]+$ ]] && [[ "$offset" -ge 0 ]]; then
+        echo "  OK: Secondary firmware $extra_name is contained in $FD_BASENAME at $(printf '0x%x' "$offset")"
+    else
+        echo "  WARNING: $extra_name ($(stat -c%s "$extra") bytes) is NOT contained verbatim in
+$FD_BASENAME. It may be compressed inside the image, or it may be a separate
+component that the Windows updater flashes on its own. If the latter, the
+update induced by the .cab file produced by this script will not touch it,
+and that component will stay on its current version." >&2
+    fi
+done
+
+# --------------------------------------------------------------------------- #
+# Read the BIOS version string
+#
+# Used for the .cab filename and the metainfo description.
+#
+# Insyde images carry a BIOS Version Data Table, introduced by a $BVDT tag and
+# followed by '$'-prefixed, NUL-terminated records; the first non-empty record
+# is the version. Both a Legion and a Yoga package place it identically:
+#
+#    $BVDT $\0\0\0 $\0\0\0 $Q7CN78WW\0 ... $Legion Pro 7 16IAX10H
+#    $BVDT $\0\0\0 $\0\0\0 $QFCN29WW\0 ... $KLS7A
+#
+# Reading it this way assumes nothing about Lenovo's naming scheme, so it also
+# works on models that do not use the four-letter + two-digit + WW form. It is
+# also correct on packages whose image is not named after the BIOS version
+# (e.g. KLS7A.bin, where the version is QFCN29WW), which the old
+# "strip Win, strip .fd" approach would have gotten wrong.
+#
+# Fall back to the .exe filename if the table is missing or unrecognized.
+# --------------------------------------------------------------------------- #
+BIOS_VERSION=$(python3 -c '
+import sys
+d = open(sys.argv[1], "rb").read()
+i = d.find(b"$BVDT")
+if i >= 0:
+    pos = i + 5
+    for _ in range(8):
+        if d[pos:pos+1] != b"$":
+            break
+        end = d.find(b"\x00", pos)
+        if end < 0:
+            break
+        token = d[pos+1:end]
+        pos = end + 1
+        while d[pos:pos+1] == b"\x00":
+            pos += 1
+        if token:
+            print(token.decode("ascii", "replace"))
+            break
+' "$FD_FILE" 2>/dev/null || true)
+
+if [[ -n "$BIOS_VERSION" ]]; then
+    echo "==> BIOS version string: $BIOS_VERSION (from the image)"
+else
+    BIOS_VERSION=$(basename "${EXE%.*}" | tr '[:lower:]' '[:upper:]')
+    echo "==> BIOS version string: $BIOS_VERSION (from the .exe filename)"
+fi
 
 # --------------------------------------------------------------------------- #
 # Read the System Firmware GUID and current ESRT version from sysfs
@@ -133,7 +267,7 @@ cat > "$WORK/firmware.metainfo.xml" <<METAINFO
 METAINFO
 
 # --------------------------------------------------------------------------- #
-# Copy the .fd file as firmware.bin (fwupd convention)
+# Copy the firmware image as firmware.bin (fwupd convention)
 # --------------------------------------------------------------------------- #
 cp "$FD_FILE" "$WORK/firmware.bin"
 

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -29,6 +29,8 @@ die()  { echo "${C_RED}${C_BOLD}ERROR:${C_OFF} $*" >&2; exit 1; }
 warn() { echo "${C_YELLOW}${C_BOLD}WARNING:${C_OFF} $*" >&2; }
 ok()   { echo "${C_GREEN}${C_BOLD}  OK:${C_OFF} $*"; }
 
+hex() { [[ "$1" =~ ^[0-9]+$ ]] && printf '0x%08X' "$1" || true; }
+
 # --------------------------------------------------------------------------- #
 # Argument parsing
 # --------------------------------------------------------------------------- #
@@ -265,7 +267,7 @@ done
 Is this a UEFI system with an EFI System Resource Table?"
 
 echo "==> System Firmware GUID: $FW_GUID"
-echo "==> Current firmware version (ESRT): $FW_CURRENT_VERSION"
+echo "==> Current firmware version (ESRT): $FW_CURRENT_VERSION ($(hex "$FW_CURRENT_VERSION"))"
 
 # --------------------------------------------------------------------------- #
 # Verify the image targets this machine.
@@ -347,15 +349,113 @@ fi
 # --------------------------------------------------------------------------- #
 # Determine the version number to put in the .cab metadata
 #
-# We set it to current_version + 1 so fwupd treats this as an upgrade.
-# The actual version validation is handled by the UEFI firmware itself
-# during the capsule update.
+# The binary image stores the firmware version in the 4 bytes after the $ESRT
+# tag, using little endian. Read this to correctly package metadata information
+# for fwupd.
+#
+# That 32-bit value is not opaque: the low byte holds the two BIOS version
+# digits as hex, and the upper three bytes identify the platform and stay
+# constant across updates on a given machine:
+#
+#   QFCN26WW -> 0x61250026   (tested Yoga Pro 7 14ASP10 machine, before updating)
+#   QFCN29WW -> 0x61250029   (the package that updated it)
+#   Q7CN78WW -> 0x73315078   (a Legion Pro 7i 16IAX10H package)
+#   SMCN20WW -> 0x61420020   (a Legion Pro 7 16AFR10H package)
+#
+# So the whole value can be predicted: take the ESRT version this machine
+# currently reports, replace its low byte with the digits from the package's
+# own version string, and the result must equal what the image contains. That
+# validates all four bytes rather than just the last one, and it uses two
+# independently sourced numbers -- one from sysfs, one from the image.
+#
+# Notice that this is only for packaging reasons: the actual version
+# validation is handled by the UEFI firmware itself during the capsule update.
+# That said, this is still useful to make the metadata more accurate.
+#
+# If anything here doesn't line up, those bytes mean something other than a
+# version on this model, so print a warning and fall back to the original
+# scheme of "current version + 1" to still make fwupd treat this as an upgrade.
 # --------------------------------------------------------------------------- #
-# Strip any non-numeric characters (fwupd sometimes returns formatted versions)
-NUMERIC_VERSION=$(echo "$FW_CURRENT_VERSION" | tr -cd '0-9')
-[[ -n "$NUMERIC_VERSION" ]] || die "Could not parse current firmware version: $FW_CURRENT_VERSION"
-NEW_VERSION=$((NUMERIC_VERSION + 1))
-echo "==> Metadata version for .cab: $NEW_VERSION"
+NEW_VERSION=$(python3 -c '
+import sys
+from pathlib import Path
+image = Path(sys.argv[1]).read_bytes()
+esrt_tag = b"$ESRT"
+n = image.count(esrt_tag)
+n == 1 or sys.exit(1)
+p = image.index(esrt_tag) + len(esrt_tag)
+len(image[p:p+4]) == 4 or sys.exit(1)
+print(int.from_bytes(image[p:p+4], byteorder="little"))
+' "$FD_FILE" 2>/dev/null || echo -1)
+
+FALLBACK_REASON=""
+
+if [[ "$NEW_VERSION" -lt 0 ]]; then
+    FALLBACK_REASON="the BIOS image doesn't match the known \$ESRT firmware version packaging convention"
+
+elif [[ "$BIOS_VERSION" =~ ^[A-Z0-9]{4}([0-9]{2})WW$ ]]; then
+    PKG_DIGITS="${BASH_REMATCH[1]}"
+
+    if [[ "$FW_CURRENT_VERSION" =~ ^[0-9]+$ ]] &&
+       [[ "$DMI_BIOS_VERSION" =~ ^[A-Z0-9]{4}([0-9]{2})WW ]]; then
+        CUR_DIGITS="${BASH_REMATCH[1]}"
+        CUR_LOW=$(printf '%02x' $((FW_CURRENT_VERSION & 0xFF)))
+
+        if [[ "$CUR_LOW" != "$CUR_DIGITS" ]]; then
+            # The encoding does not even hold for the firmware already running,
+            # so it cannot be used to predict the packaged one.
+            FALLBACK_REASON=$(printf \
+                "this machine's ESRT version 0x%08X ends in '%s', which doesn't match %s" \
+                "$FW_CURRENT_VERSION" "$CUR_LOW" "$DMI_BIOS_VERSION")
+        else
+            EXPECTED_VERSION=$(( (FW_CURRENT_VERSION & 0xFFFFFF00) | 16#$PKG_DIGITS ))
+            if [[ "$NEW_VERSION" -ne "$EXPECTED_VERSION" ]]; then
+                FALLBACK_REASON=$(printf \
+                    "the image's \$ESRT version is 0x%08X but %s on this machine implies 0x%08X" \
+                    "$NEW_VERSION" "$BIOS_VERSION" "$EXPECTED_VERSION")
+            fi
+        fi
+    else
+        # No usable current version to reconstruct from; check what we can,
+        # namely that the low byte decodes to the packaged version's digits.
+        NEW_LOW=$(printf '%02x' $((NEW_VERSION & 0xFF)))
+        if [[ "$NEW_LOW" != "$PKG_DIGITS" ]]; then
+            FALLBACK_REASON=$(printf \
+                "the image's \$ESRT version 0x%08X ends in '%s', which doesn't match %s" \
+                "$NEW_VERSION" "$NEW_LOW" "$BIOS_VERSION")
+        fi
+    fi
+fi
+
+if [[ -n "$FALLBACK_REASON" ]]; then
+    # The original scheme: fwupd only needs a number greater than the installed
+    # one to treat the .cab as an update. Note this is occasionally right by coincidence:
+    # since the low byte holds the version digits in hex, a decimal "+1" matches the real
+    # value only for single-step updates that don't cross a ten (26->27 yes; 26->29 or 29->30 no).
+    # Anything else leaves fwupd expecting a version the firmware will not report.
+
+    warn "$FALLBACK_REASON;"
+    warn "falling back to 'current firmware version + 1' fwupd metadata."
+    echo ""
+    warn "The BIOS update itself is unaffected -- the UEFI firmware validates the real"
+    warn "version during capsule update -- but fwupd compares the version it was"
+    warn "promised against the one the firmware reports after the update, so"
+    warn "'fwupdmgr get-history' may record a successful update as failed."
+    echo ""
+    warn "This mismatch in the reported update history is harmless if the BIOS"
+    warn "update itself succeeds."
+
+    # Strip any non-numeric characters (fwupd sometimes returns formatted versions)
+    NUMERIC_VERSION=$(echo "$FW_CURRENT_VERSION" | tr -cd '0-9')
+    [[ -n "$NUMERIC_VERSION" ]] || die "Could not parse current firmware version: $FW_CURRENT_VERSION"
+    NEW_VERSION=$((NUMERIC_VERSION + 1))
+    NEW_VERSION_INFO="installed version + 1"
+else
+    ok "The BIOS image matches the known \$ESRT firmware version packaging convention"
+    NEW_VERSION_INFO=$(hex "$NEW_VERSION")
+fi
+
+echo "==> Metadata version for .cab: $NEW_VERSION ($NEW_VERSION_INFO)"
 
 # --------------------------------------------------------------------------- #
 # Get system product name for the metainfo

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -12,6 +12,11 @@
 #
 # Requirements: 7z, gcab, fwupdmgr, python3
 #
+# Note: the script reads the EFI System Resource Table, which is root-only,
+# so the script will ask for sudo up front. Everything it writes goes to a
+# temporary directory and to the .cab beside your .exe; nothing is
+# actually flashed here.
+#
 # IMPORTANT: Ensure AC power is connected and battery is above 30% before
 # installing. Do NOT interrupt the reboot after installation.
 
@@ -55,6 +60,14 @@ fi
 for cmd in 7z gcab fwupdmgr python3; do
     command -v "$cmd" &>/dev/null || die "'$cmd' is required but not found. Please install it."
 done
+
+# --------------------------------------------------------------------------- #
+# Check for root access
+# --------------------------------------------------------------------------- #
+if [[ "$EUID" -ne 0 ]]; then
+    echo "==> Reading the ESRT needs root; requesting sudo now."
+    sudo -v || die "sudo authentication failed."
+fi
 
 # --------------------------------------------------------------------------- #
 # Set up working directory
@@ -355,12 +368,18 @@ cp "$FD_FILE" "$WORK/firmware.bin"
 
 # --------------------------------------------------------------------------- #
 # Build the .cab
+#
+# If the script was invoked through sudo, gcab runs as root and the .cab ends
+# up owned by root, leaving the user unable to overwrite or delete it without
+# e.g. rm -f.
+# Hand it back to whoever called.
 # --------------------------------------------------------------------------- #
 OUTPUT_DIR=$(dirname "$(realpath "$EXE")")
 CAB_NAME="${BIOS_VERSION}.cab"
 OUTPUT_CAB="${OUTPUT_DIR}/${CAB_NAME}"
 
 (cd "$WORK" && gcab --create "$OUTPUT_CAB" firmware.metainfo.xml firmware.bin)
+[[ -n "${SUDO_USER:-}" ]] && chown "$SUDO_USER" "$OUTPUT_CAB"
 echo "==> Created: $OUTPUT_CAB"
 
 echo ""

--- a/lenovo-bios-fwupd.sh
+++ b/lenovo-bios-fwupd.sh
@@ -22,7 +22,12 @@
 
 set -euo pipefail
 
-die() { echo "ERROR: $*" >&2; exit 1; }
+C_RED=$'\033[0;31m'; C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'
+C_BOLD=$'\033[1m';   C_OFF=$'\033[0m'
+
+die()  { echo "${C_RED}${C_BOLD}ERROR:${C_OFF} $*" >&2; exit 1; }
+warn() { echo "${C_YELLOW}${C_BOLD}WARNING:${C_OFF} $*" >&2; }
+ok()   { echo "${C_GREEN}${C_BOLD}  OK:${C_OFF} $*"; }
 
 # --------------------------------------------------------------------------- #
 # Argument parsing
@@ -169,13 +174,14 @@ print(haystack.find(needle) if needle else -1)
 ' "$FD_FILE" "$extra" 2>/dev/null || echo -1)
 
     if [[ "$offset" =~ ^[0-9]+$ ]] && [[ "$offset" -ge 0 ]]; then
-        echo "  OK: Secondary firmware $extra_name is contained in $FD_BASENAME at $(printf '0x%x' "$offset")"
+        ok "$(printf 'Secondary firmware %s is contained in %s at 0x%x' \
+              "$extra_name" "$FD_BASENAME" "$offset")"
     else
-        echo "  WARNING: $extra_name ($(stat -c%s "$extra") bytes) is NOT contained verbatim in
+        warn "$extra_name ($(stat -c%s "$extra") bytes) is NOT contained verbatim in
 $FD_BASENAME. It may be compressed inside the image, or it may be a separate
 component that the Windows updater flashes on its own. If the latter, the
 update induced by the .cab file produced by this script will not touch it,
-and that component will stay on its current version." >&2
+and that component will stay on its current version."
     fi
 done
 
@@ -270,7 +276,7 @@ import sys, uuid
 image = open(sys.argv[1], "rb").read()
 sys.exit(0 if uuid.UUID(sys.argv[2]).bytes_le in image else 1)
 ' "$FD_FILE" "$FW_GUID"; then
-    echo "  OK: $FD_BASENAME targets this machine's System Firmware GUID."
+    ok "$FD_BASENAME targets this machine's System Firmware GUID."
 else
     die "$FD_BASENAME does not reference this machine's System Firmware GUID
 ($FW_GUID). This package is for a different device."
@@ -306,7 +312,7 @@ DMI_BIOS_VERSION=$(cat /sys/class/dmi/id/bios_version 2>/dev/null)
 
 if [[ "$DMI_BIOS_VERSION" =~ ^[A-Z0-9]{4}[0-9]{2}WW ]]; then
     if [[ "${BIOS_VERSION:0:4}" == "${DMI_BIOS_VERSION:0:4}" ]]; then
-        echo "  OK: Platform code matches: ${BIOS_VERSION:0:4} (machine on $DMI_BIOS_VERSION, package $BIOS_VERSION)"
+        ok "Platform code matches: ${BIOS_VERSION:0:4} (machine on $DMI_BIOS_VERSION, package $BIOS_VERSION)"
     else
         die "Platform code mismatch.
   image  : $BIOS_VERSION


### PR DESCRIPTION
Hi @nadimkobeissi,

Thank you so much for this repo, I was able to use it to update the bios on my Lenovo Yoga Pro 7 14ASP10.

<img width="823" height="525" alt="yoga_bios_update_cropped" src="https://github.com/user-attachments/assets/599121c2-663f-4acb-86c9-ba5cf9223036" />

In order to do so, though, I had to make some changes to the script. While working on this, I also added some improvements to the UX of the script, such as compatibility checks to prevent accidentally using the wrong image, improved script output/diagnostics and documentation, and more accurate fwupd metadata.

I know you don't appreciate seeing too much stuff in a PR all at once, so let me immediately go on record and say that only the first 2 patches are strictly necessary to make the script work on my yoga; anything after that is more or less optional. Feel free to take only some commits (I can also send them separately if you prefer). That said, I was able to reverse engineer some details about the BIOS image packaging that were too interesting not to share (plus, I think it's always better to include checks guarding against user error).

#### AI disclaimer
While developing this patch series I used Claude to debug/bugfix my poor bash skills and to validate my findings (e.g. to systematically run tests on the script). That said, *the design of the code and the entire patch series is my own, and every relevant bit of reverse engineering of the Insyde package was carried out by me* by reading text files or scrolling through binaries in a hex editor (see below). *Everything here reflects my own work and understanding*, and *I validated the results by updating the BIOS on my hardware at my own risk*. Claude was mostly used to compensate for my own laziness regarding the routine boring tasks, not as a brain outsourcing machine.

## Patch series breakdown

### Patches 1-2: add Yoga Pro 7 14ASP10 support (`.bin` instead of `.fd`, `number` instead of `plain`)

#### Different binary file names/extensions and `platform.ini`
On the Yoga Pro 7 Gen 10 14ASP10, the script fails outright: the package contains no `Win<version>.fd`. Instead it contains two images: `KLS7A.bin` (an internal board code for this device) and `Ecb.bin` (likely "embedded controller BIOS/block", see below); apart from that the Insyde H2OFFT stuff is almost identical (the Windows-specific libraries are organized a bit differently, but it clearly is the same BIOS vendor/flashing mechanism).

It's clear that `KLS7A.bin` is the equivalent of `Win<...>.fd` on the Legion:
- Inspecting the `.bin` and `.fd` files using UEFITool reveals they are mostly the same apart from some obvious differences (AMD vs Intel CPU microcode, AMD PSP directories vs an Intel ME region, Intel-only `$_IFLASH_ME_IMG_` section, etc.), and the interpretable raw bytes parsed via hex editor follow the same packaging schemes (more on this below).
- The `platform.ini` file contains this section in the Yoga package:
```ini
[FDFile]
FileName=KLS7A.bin
;(wW)
;FileName          default : empty.
;                   String : Utility always load this file.
;                            If the FileName is empty, utility will search current directory
;                              and load the first found FD file.
```
and this on the Legion:
```ini
[FDFile]
FileName=
;(wW)
;FileName          default : empty.
;                   String : Utility always load this file.
;                            If the FileName is empty, utility will search current directory
;                              and load the first found FD file.
```
It's then clear that on the Yoga it suffices to replace the current "look for `.fd` file in the extracted package" behavior with logic that honors this variable; therefore, patch 1 reads this variable and looks for the corresponding file if not empty, otherwise it follows the same "grab the first `.fd` file" rule.

#### Secondary firmware binary blobs
The yoga contains another `.bin` file, but the Insyde capsule only takes a single image; this initially worried me, as I thought I was risking flashing half a BIOS. Luckily, it turns out that this file can be safely ignored.

- A quick python script like e.g. this:
```python
from pathlib import Path

main = Path('./KLS7A.bin').read_bytes()
secondary = Path('./Ecb.bin').read_bytes()

print(f'0x{main.find(secondary):x}')
```
returns `0x1817b0`, which means that the secondary blob is actually contained verbatim inside the main one. The separate `Ecb.bin` file contains no information that isn't already inside the main image.
- Trying to open this file via UEFITool returns an error, meaning that it's not a proper BIOS image (unlike `KLS7A.bin`); instead, inspecting it via hex editor, reveals a certain `ITE5508` string and a lot of references to functions related to power states, battery, connections, etc.; given [what I was able to find online](https://www.atombilgisayar.com/it5508vg-512-cwa-lenovo-embedded-controller-5550), I'd say this `Ecb.bin` is the embedded controller's BIOS, the firmware only for the controller that regulates KBC (Keyboard, Power Management, Thermal Control).
- `platform.ini` has an `[UpdateEC]` section detailing how EC firmware would be flashed *separately* from the main image; this section has `Flag=0` on the yoga, entirely disabling this behavior, in good agreement with the above findings. However, there are mentions of at least two other mechanisms that allow for multiple `.bin`/`.fd` files to be flashed separately from the main image and potentially within Windows rather than via UEFI capsule (`MEFileName` and `MULTI_FD`). `MULTI_FD` in particular means the package ships several images and picks one by probing the hardware, which cannot be reproduced here, so the script refuses those packages outright. Similarly, `MEFileName` names a separate Intel ME image, which H2OFFT flashes from inside Windows (via `MEProgram`, `FWUpdLcl.exe` by default) before the BIOS.

Overall, patch 1 makes the script look for separate `.bin` files and check via python if they're already contained inside the main image, which implies it's safe to ignore them as a simple heuristics. If the image is actually separate, it only produces a warning, because this likely means that the separate component's firmware won't be updated alongside the main BIOS, but that should be safe in that it likely won't brick the laptop (hence why a nonfatal warning). The script and documentation tell users about this either way.
Instead, in the case of `MULTI_FD`, since the image to flash is chosen at runtime by hardware detection that cannot be reproduced here, the script stops early. `MEFileName` needs no special handling: an ME image named there would be a separate file that isn't inside the BIOS image, so the containment check above already catches it and warns.

Note: the `MULTI_FD` and `MEFileName` behavior above was inferred from Insyde's documentation inside platform.ini, not observed; every package I looked at has `MULTI_FD` `Flag=0` and an empty `MEFileName`, so the guard has never actually fired on a real, unedited tested Lenovo package. It would be interesting to collect some stats on Lenovo packaging across different devices; I may do a bit of web scraping later on, but hopefully user submissions will help carry this out more organically.

#### BIOS version parsing from the image itself

Since for the Yoga the original "get BIOS version from `.fd` filename" logic doesn't apply, I replaced this with extracting this string from the BIOS image itself. In particular, I found that the same BIOS version string is actually encoded in the image itself, which arguably is a more authoritative source of truth than the file names.

The Yoga's `qfcn29ww.exe` package's `KLS7A.bin` image contains a `$BVDT` (BIOS version data table, I'd guess) tag, which is followed by the BIOS version string; the same holds for the Legion. Decoding the raw bytes using a hex editor one obtains:
```
Yoga Pro 7 14ASP10:    $BVDT$...$...$QFCN29WW................$KLS7A
Legion Pro 7 16IAX10H: $BVDT$...$...$Q7CN78WW................$Legion Pro 7 16IAX10H
Legion Pro 7 16AFR10H: $BVDT$...$...$SMCN20WW................$Legion Pro 7 16AFR10H
```
Interestingly enough, in these three packages, the ones that use the "first `.fd` file found" default have the commercial name readable here, whereas the one using a customized image name reports the board code instead.
Whatever the case, the BIOS version is clearly readable, and in all cases it follows the rule `$BVDT$<3 zeros>$<3 zeros>$<8 bytes for the BIOS version>`. Therefore, patch 1 replaces the original `Win<...>.fd` scheme (which would fail on the Yoga) with grabbing the BIOS version decoded here. If this search fails, the script falls back to reading the `.exe` filename *capitalized*, which would still work on the Yoga as well as the already supported models. Clearly this would fail if the user renamed the `.exe`, but later in the series checks are introduced to validate this string either way.
I think it's safe to assume that all devices using this BIOS format comply with the above scheme, but I still added the fallback in case this information is packaged differently on a device that could still work with this script.

#### Optional `VersionFormat` argument

On the Lenovo Yoga Pro 7 14ASP10, the line:
```xml
  <value key="LVFS::VersionFormat">plain</value>
```
causes this error when trying to install the .cab package:
```sh
  Firmware version formats were different, device was 'number' and release is 'plain'
```
This error disappears by replacing `plain` with `number` in the metainfo. I tried studying [fwupd's source](https://github.com/fwupd/fwupd/blob/0e8d1470dc560c2f6263e474aa4730d85d091306/src/fu-release.c#L623) to figure out why the Yoga needs `number` when the models already in the table apparently work with `plain`, in order to see if there was a way to automate choosing the right parameter based on the device, but in the end I got lazy and simply added an optional argument to the script to let the user pick the right one based on if an error like the above is printed. I would be happy to replace this with more elegant solutions.

### Other patches in the series

Here are the somewhat optional patches summarized.

#### Patch 3: add section explaining unplugged device error

fwupd will refuse to install the .cab on devices currently running on battery, but the corresponding error is somewhat cryptic:
```sh
Device X [System Firmware] does not currently allow updates
```
Now that we have a proper troubleshooting section, we can add an entry explaining this error.

#### Patch 4: Add safety checks: verify image GUID and platform code before building the .cab

Nothing currently stops you pointing the script at the wrong package: it reads the System Firmware GUID from your own ESRT and writes it into the metainfo regardless of what the image actually is. This patch adds two checks, which turn out to be complementary rather than redundant.

The first is a GUID match. Insyde images embed the ESRT System Firmware GUID they belong to; for simplicity's sake, rather than locate and decode it, the script converts *this machine's* GUID (which it already reads for the metainfo) into its raw 16 bytes and checks the image contains them. Using python in the opposite direction is IMHO a bit simpler and faster than decoding the mixed-endianness UUID format.

The second compares the four-character platform code from the image's version string against `/sys/class/dmi/id/bios_version`.

I initially thought the GUID check made the second one pointless, until I looked at the two Pro 7 Gen 10 Legions:
```
Legion Pro 7 16IAX10H (Intel, Q7CN78WW) be248459-caf2-4b09-af02-69b6a49974c1
Legion Pro 7 16AFR10H (AMD, SMCN20WW) be248459-caf2-4b09-af02-69b6a49974c1
Yoga Pro 7 14ASP10 (AMD, QFCN29WW) f390d9ea-f5ca-4bcc-9ce9-d15f59902d9b
```

Clearly, the GUID is per *family*, and only the platform code (`Q7CN` vs `SMCN`) tells those two apart. Conversely, the platform code check is skipped on machines whose BIOS version doesn't follow the `<4 chars><2 digits>WW` shape, where the GUID check is the only one that runs. Neither subsumes the other, so both are independently retained and fatal on mismatch.

#### Patch 5: Ask for sudo up front instead of mid-script

Currently the script asks for sudo in the middle of the execution, which I find awkward and annoying, so this patch asks for sudo access upfront while adding documentation to explain why it's needed and that users should verify independently.

#### Patch 6: Colorize error/warning/success output

This is simply to make the script's output more readable. Self-explanatory.

#### Patch 7: Print/improve system diagnostics for user experience and reports

Prints product name, product family, current BIOS version, EC firmware release and the chosen version format before doing any work. This is mostly so that issue reports from unlisted models are actually useful in collecting some statistics about Lenovo packaging convention, rather than simply saying "device X works/doesn't work"; by asking people to paste the script's output when opening issues, we can collect some potentially useful data.

#### Patch 8: Reject BIOS downgrades and warn on reinstalls

A simple self-explanatory check, performed by comparing the installed and package BIOS versions under the assumption that the device's BIOS string is `<....NNWW>`.

#### Patch 9: Extract new firmware version for accurate fwupd metadata packaging

The script packages "installed version + 1" so fwupd treats the .cab as an upgrade.
That works when it comes to convincing fwupd that this is an update, since the real validation happens in the UEFI firmware during the capsule update anyway, but the actual new version is sitting in the image: 4 bytes, little endian, right after an `$ESRT` tag. Avoiding hardcoding +1 is useful because it produces spurious errors in fwupdmgr's history if a user skips intermediate BIOS versions, which is still allowed (see edit at the bottom), and which would require adding more than 1 to the current fw_ver.

Furthermore, that `$ESRT` value isn't opaque. Its low byte holds the two BIOS version digits as hex, and the upper three bytes identify the platform and stay constant across updates on a given machine:

```
QFCN26WW -> 0x61250026 (what my Yoga was originally on)
QFCN28WW -> 0x61250028 (an older update package I downloaded)
QFCN29WW -> 0x61250029 (the newer update package I actually installed, and what it's on now)
SMCN20WW -> 0x61420020 (Legion Pro 7 16AFR10H)
```


So rather than trusting those bytes, the patch reconstructs them: take the ESRT version the machine currently reports, swap in the digits from the package's own version string, and require an exact match against the image.
That checks all four bytes using two independently sourced numbers, one from sysfs and one from the image.
It also verifies the encoding holds for the firmware already running before relying on it. If anything doesn't line up, warn and fall back to "installed + 1", leaving fwupd's view exactly as it is today.

Verified end to end: after installing the generated .cab, `fw_version` read `1629814825` with `last_attempt_status 0`, matching the value read from the image beforehand.

#### Patch 10: Add Legion Pro 7 16AFR10H as a packaging-only test entry

The script passed every check on my other Lenovo and produced a .cab, but I couldn't install it since that machine is already on the latest BIOS (I dual-boot Windows on this Legion, and I explicitly updated the BIOS from my windows SSD in the past [to validate my `mokutil` secure boot guide](https://github.com/marco-giunta/legion-pro7-gen10-audio/blob/legion_audio/docs/secure_boot.md#re-enrolling-mok-certificates-after-bios-updates-from-a-windows-partition)). 
Therefore, this is recorded as a distinct status, since the capsule path is unverified there.

#### Patch 11: Bump version number to 2.0

Self-explanatory.

## in conclusion...
Thanks again for this amazing work, apologies for the massive PR, and let me know your thoughts. Feel free to ask for edits as needed. I'm happy to cooperate on this nice project.

---
*Edit:* On second thought, patch 9 is less cosmetic than I originally thought.
fwupd checks the post-reboot version against what the metadata promised, and records the update as failed when they differ. Since I flashed my Yoga with the script *before* adding this commit, my own history shows:

```
System Firmware:
Previous version: 1629814822
Update state: Failed
Update error: failed to run update on reboot:
expected 1629814823 and got 1629814825
```

Despite this, the BIOS updated perfectly: `last_attempt_status 0`, and `fw_version` went to `1629814825` as the image said it would (alongside the BIOS version going from QFCN26WW to QFCN29WW, as expected). Only fwupd disagrees, because the synthesized `installed + 1` promised `1629814823` and the firmware wrote its real version instead. This is because I jumped from version 26 to 29, so +1 instead of +3 is inaccurate.

Even with a single-step update the decimal +1 can cause a mismatch if the update crosses a 10. For example, I was able to download the older `smcn19ww.exe` package for the 16AFR10H, and its `$ESRT` tag yields firmware version 0x61420019, as expected. Compared to 0x61420020 for BIOS version SMCN20WW, the difference between these two values is 7 instead of 1 to account for the difference between base 16 and 10, given that the string is intentionally skipping letters to keep the 2 low bytes as encoding the BIOS version.

Overall, packaging the actual version removes the discrepancy, so a successful update is recorded as successful.
Again, this error in `fwupdmgr get-history` is harmless, but it's best to prevent it.

I've edited the commit message of patch 9 to make this clearer.
Also, there are multiple force-pushed because I had made some mistakes while updating the commit message (sorry!)